### PR TITLE
Implemented #9

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,7 +24,6 @@ or:
 
 
 ## Library methods
-
     >>> # Returns the frequency of the note (key) keys from A0
     >>> melopy.frequency_from_key(49)
     440
@@ -58,6 +57,12 @@ or:
     >>> # Calls iterate with the starting note and the pattern [3, 4]
     >>> melopy.generate_minor_triad('C5')
     ['C5', 'D#5', 'G5']
+
+All methods that return lists support choosing return types. The defualt return type is a list. example:
+    >>> generate_minor_scale("A4","tuple")
+    ('A4', 'B4', 'C5', 'D5', 'E5', 'F5', 'G5')
+    >>> generate_minor_scale("A4","dict")
+    {0: 'A4', 1: 'B4', 2: 'C5', 3: 'D5', 4: 'E5', 5: 'F5', 6: 'G5'}
 
 
 

--- a/melopy/melopy.py
+++ b/melopy/melopy.py
@@ -10,7 +10,7 @@ class MelopyValueError(ValueError): pass
 def bReturn(output,Type):
 	"""Returns a selected output assuming input is a list"""
 	O = {} #Empty local dictionary
-	if type(Type) is "list":
+	if isinstance(output, list):
 		if Type.lower() == "list":
 			return output
 		elif Type.lower() == "tuple":
@@ -22,7 +22,7 @@ def bReturn(output,Type):
 		else:
 			raise MelopyGenericError("Unknown type: "+Type)
 	else:
-		MelopyGenericError("Input to bReturn is not a list! Input: "+output)
+		MelopyGenericError("Input to bReturn is not a list! Input: "+str(output))
 
 	
 
@@ -74,12 +74,13 @@ def generate_major_scale(start, rType="list"):
 	"""Generates a major scale using the pattern [2,2,1,2,2,2] (Returns: List)"""
 	major_steps = [2,2,1,2,2,2]
 	return bReturn(iterate(start, major_steps), rType)
-	
-def generate_minor_scale(start, rType="list"):
+
+def generate_minor_scale(start, rType="list"): #Natural minor
 	"""Generates a minor scale using the pattern [2,1,2,2,1,2] (Returns: List)"""
 	minor_steps = [2,1,2,2,1,2]
 	return bReturn(iterate(start, minor_steps),rType)
-	
+	#To be added: Harmonic and Melodic minor scales. Patterns: [2,1,2,2,2,1,2] | [2,1,2,2,2,2,1]
+
 def generate_chromatic_scale(start, rType="list"):
 	"""Generates a chromatic scale using the pattern [1,1,1,1,1,1,1,1,1,1,1] (Returns: List)"""
 	chromatic_steps = [1,1,1,1,1,1,1,1,1,1,1]


### PR DESCRIPTION
Now supports the following:

```
>>> generate_minor_scale("A4","tuple")
('A4', 'B4', 'C5', 'D5', 'E5', 'F5', 'G5')
>>> generate_minor_scale("A4","dict")
{0: 'A4', 1: 'B4', 2: 'C5', 3: 'D5', 4: 'E5', 5: 'F5', 6: 'G5'}
```

Enjoy! :D
