### PR TITLE
Adding generate_mode() function.

### DIFF
--- a/melopy/melopy.py
+++ b/melopy/melopy.py
@@ -3,9 +3,36 @@
 
 import wave, struct, random, math
 import os, sys 
+from collections import deque
 
 class MelopyGenericError(Exception): pass
 class MelopyValueError(ValueError): pass
+
+DIATONIC_SEQUENCE = [2, 2, 1, 2, 2, 2, 1]
+# A dict of mode names mapping to steps of rotation from DIATONIC_SEQUENCE
+MODES = {
+"ionian":0,
+"dorian":1,
+"phrygian":2,
+"lydian":3,
+"mixolydian":4,
+"aeolian":5,
+"locrian":6,
+}
+
+def get_diatonic_sequence(name):
+    """Return a diatonic sequence by name."""
+    seq = deque(DIATONIC_SEQUENCE)
+    seq.rotate(-1*MODES[name.lower()]) 
+    return list(seq)
+
+
+def generate_mode(start, name, rType="list"):
+    """Generates a mode using a sequence derived from DIATONIC_SEQUENCE (Returns: List)"""
+    steps = get_diatonic_sequence(name)[:-1]   # lop off last item to conform with other generate_*() functions
+    return iterate(start, steps, rType)
+
+
 
 def bReturn(output, Type):
     """Returns a selected output assuming input is a list"""

--- a/tests/melopy_tests.py
+++ b/tests/melopy_tests.py
@@ -54,7 +54,45 @@ class LibraryFunctionsTests(TestCase):
         start = 'A5'
         should_be = ['A5', 'C6', 'D6', 'E6', 'G6']
         assert generate_minor_pentatonic_scale(start) == should_be
-       
+	
+
+    def test_generate_ionian_mode(self):
+        start = 'D4'
+        should_be = ['D4', 'E4', 'F#4', 'G4', 'A4', 'B4', 'C#5']
+        assert generate_mode(start, 'ionian') == should_be
+
+    def test_generate_dorian_mode(self):
+        start = 'E4'
+        should_be = ['E4', 'F#4', 'G4', 'A4', 'B4', 'C#5', 'D5']
+        assert generate_mode(start, 'dorian') == should_be
+
+    def test_generate_phrygian_mode(self):
+        start = 'F#4'
+        should_be = ['F#4', 'G4', 'A4', 'B4', 'C#5', 'D5', 'E5']
+        assert generate_mode(start, 'phrygian') == should_be
+
+    def test_generate_lydian_mode(self):
+        start = 'G4'
+        should_be = ['G4', 'A4', 'B4', 'C#5', 'D5', 'E5','F#5']
+        assert generate_mode(start, 'lydian') == should_be
+
+    def test_generate_mixolydian_mode(self):
+        start = 'A4'
+        should_be = ['A4', 'B4', 'C#5', 'D5', 'E5','F#5', 'G5']
+        assert generate_mode(start, 'mixolydian') == should_be
+
+    def test_generate_aeolian_mode(self):
+        start = 'B4'
+        should_be = ['B4', 'C#5', 'D5', 'E5','F#5', 'G5', 'A5']
+        assert generate_mode(start, 'aeolian') == should_be
+
+    def test_generate_locrian_mode(self):
+        start = 'C#5'
+        should_be = ['C#5', 'D5', 'E5','F#5', 'G5', 'A5', 'B5']
+        assert generate_mode(start, 'locrian') == should_be
+    
+    
+    
     def test_generate_major_triad(self):
         start = 'A4'
         should_be = ['A4', 'C#5', 'E5']


### PR DESCRIPTION
As originally suggested on reddit (http://www.reddit.com/r/Python/comments/jvrfd/i_recently_started_working_on_a_barebones/c2fmquj).
## 

Adding generate_mode() function. Similar to the other generate_`scale`() functions, it takes a
start param and an rType param, but also takes a name param which corresponds to the modern musical
modes (http://en.wikipedia.org/wiki/Musical_mode#Modern_modal_scales_on_the_natural_notes). Modes
are generated from the one list (DIATONIC_SEQUENCE). Have dropped the octave value to conform
with the existing generate_`scale`() functions.

generate_mode('c', 'ionian') should correspond to generate_major_scale('c') and
generate_mode('c', 'aeolian') should correspond to generate_minor_scale('c').

Also adding tests for generate_mode().
