### PR TITLE
join data_frames with empty byte instead of empty string

### DIFF
--- a/melopy/melopy.py
+++ b/melopy/melopy.py
@@ -213,7 +213,7 @@ class Melopy:
             data_frames.append(packed_val)
             data_frames.append(packed_val)
 
-        melopy_writer.writeframes(''.join(data_frames))
+        melopy_writer.writeframes(b''.join(data_frames))
 
         sys.stdout.write("\r[%s] 100%%" % ('='*50))
         sys.stdout.flush()


### PR DESCRIPTION
I attempted to use this library with python3 but found that I ran into an error when calling the render function. A single character addition allowed my tests to run correctly.

Originally, an attempt to call the render function would result in the following error:

> TypeError: sequence item 0: expected str instance, bytes found

data_frames is a list of byte strings and must be joined with another byte string, not a plain string. This fix joins the data_frames byte strings with an empty byte string instead of an empty plain string and avoids the error.

In python2, byte strings are just plain strings so the change from '' to b'' makes no difference to the result.
