### PR TITLE
Fix tests and imports

### DIFF
--- a/melopy/chords.py
+++ b/melopy/chords.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from utility import note_to_key, key_to_note, iterate
-from exceptions import MelopyGenericError
+from melopy.utility import note_to_key, key_to_note, iterate
+from melopy.exceptions import MelopyGenericError
 
 CHORD_INTERVALS = {
     'maj': [4,3],

--- a/melopy/melopy.py
+++ b/melopy/melopy.py
@@ -4,8 +4,8 @@
 import wave, struct, random, math
 import os, sys
 
-from utility import *
-from scales  import *
+from melopy.utility import *
+from melopy.scales  import *
 
 # same included wave functions
 # a function of frequency and tick

--- a/melopy/scales.py
+++ b/melopy/scales.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from utility import note_to_key, key_to_note, iterate
-from exceptions import MelopyGenericError
+from melopy.utility import note_to_key, key_to_note, iterate
+from melopy.exceptions import MelopyGenericError
 
 SCALE_STEPS = {
     "major":[2,2,1,2,2,2,1],

--- a/melopy/utility.py
+++ b/melopy/utility.py
@@ -11,7 +11,7 @@ def key_to_frequency(key):
 def key_to_note(key, octaves=True):
     """Returns a string representing a note which is (key) keys from A0"""
     notes = ['a','a#','b','c','c#','d','d#','e','f','f#','g','g#']
-    octave = (key + 8) / 12
+    octave = (key + 8) // 12
     note = notes[(key - 1) % 12]
 
     if octaves:

--- a/melopy/utility.py
+++ b/melopy/utility.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from math import log
-from exceptions import MelopyGenericError, MelopyValueError
+from melopy.exceptions import MelopyGenericError, MelopyValueError
 
 def key_to_frequency(key):
     """Returns the frequency of the note (key) keys from A0"""


### PR DESCRIPTION
## Change 1 (fix imports)
On trying to import:

```
from melopy.scales import generateScale
```

I got this error:
```
In [1]: from melopy.scales import generateScale
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-8766c174d199> in <module>
----> 1 from melopy.scales import generateScale

~/.local/lib/python3.8/site-packages/melopy/scales.py in <module>
      5 class MelopyValueError(ValueError): pass
      6 
----> 7 from utility import note_to_key, key_to_note
      8 
      9 def bReturn(output, Type):

ModuleNotFoundError: No module named 'utility'
```
Which was fixed by adding '`melopy.`' to the start of each melopy import.

## Change 2 (fix tests)

The tests were still failing, I think this is because `key_to_note` was expecting integer division with `/`. I have changed this to `//` and the tests pass (and the results make sense).

Thanks.